### PR TITLE
Add support for more Http Methods.

### DIFF
--- a/src/router/HttpMethod.php
+++ b/src/router/HttpMethod.php
@@ -14,4 +14,8 @@ enum HttpMethod: string {
   HEAD = 'HEAD';
   GET = 'GET';
   POST = 'POST';
+  PUT = 'PUT';
+  PATCH = 'PATCH';
+  DELETE = 'DELETE';
+  OPTIONS = 'OPTIONS';
 }

--- a/src/router/HttpMethod.php
+++ b/src/router/HttpMethod.php
@@ -18,4 +18,7 @@ enum HttpMethod: string {
   PATCH = 'PATCH';
   DELETE = 'DELETE';
   OPTIONS = 'OPTIONS';
+  PURGE = 'PURGE';
+  TRACE = 'TRACE';
+  CONNECT = 'CONNECT';
 }


### PR DESCRIPTION
in my opinion this enum should be removed and method should be typed hinted as `array<string>`, allowing multiple http methods + custom  http methods.