### PR TITLE
Fix dependency conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "hhvm": "^4.0",
     "hhvm/hsl": "^4.0.0",
     "hhvm/hhvm-autoload": "^2.0",
-    "facebook/hack-http-request-response-interfaces": "^0.1"
+    "facebook/hack-http-request-response-interfaces": "^0.2"
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION

1. merge hhvm/hack-http-request-response-interfaces#37
2. tag `0.2` on `hack-http-request-response-interfaces`
3. merge this
4. wait for `usox/hackttp` to use `hack-http-request-response-interfaces:0.2`
5. tag a minor release here.

this would allow others to use this library as `dev-master` until another minor release is tagged ( after step 3 and before 5 ).

