### PR TITLE
add MethodNotAllowedException::getAllowedMethods()

### DIFF
--- a/src/http-exceptions/MethodNotAllowedException.php
+++ b/src/http-exceptions/MethodNotAllowedException.php
@@ -11,4 +11,16 @@
 namespace Facebook\HackRouter;
 
 class MethodNotAllowedException extends HttpException {
+  public function __construct(
+    protected keyset<HttpMethod> $allowed,
+    string $message = '',
+    int $code = 0,
+    ?\Exception $previous = null,
+  ) {
+    parent::__construct($message, $code, $previous);
+  }
+
+  public function getAllowedMethods(): keyset<HttpMethod> {
+    return $this->allowed;
+  }
 }

--- a/src/router/BaseRouter.php
+++ b/src/router/BaseRouter.php
@@ -10,7 +10,7 @@
 
 namespace Facebook\HackRouter;
 
-use namespace HH\Lib\Dict;
+use namespace HH\Lib\{C, Dict};
 use function Facebook\AutoloadMap\Generated\is_dev;
 
 abstract class BaseRouter<+TResponder> {
@@ -27,22 +27,20 @@ abstract class BaseRouter<+TResponder> {
       $data = Dict\map($data, $value ==> \urldecode($value));
       return tuple($responder, new ImmMap($data));
     } catch (NotFoundException $e) {
-      foreach (HttpMethod::getValues() as $next) {
-        if ($next === $method) {
-          continue;
-        }
-        try {
-          list($responder, $data) = $resolver->resolve($next, $path);
-          if ($method === HttpMethod::HEAD && $next === HttpMethod::GET) {
-            $data = Dict\map($data, $value ==> \urldecode($value));
-            return tuple($responder, new ImmMap($data));
-          }
-          throw new MethodNotAllowedException();
-        } catch (NotFoundException $_) {
-          continue;
-        }
+      $allowed = $this->getAllowedMethods($path);
+      if (C\is_empty($allowed)) {
+        throw $e;
       }
-      throw $e;
+
+      if (
+        $method === HttpMethod::HEAD && $allowed === keyset[HttpMethod::GET]
+      ) {
+        list($responder, $data) = $resolver->resolve(HttpMethod::GET, $path);
+        $data = Dict\map($data, $value ==> \urldecode($value));
+        return tuple($responder, new ImmMap($data));
+      }
+
+      throw new MethodNotAllowedException($allowed);
     }
   }
 
@@ -51,9 +49,27 @@ abstract class BaseRouter<+TResponder> {
   ): (TResponder, ImmMap<string, string>) {
     $method = HttpMethod::coerce($request->getMethod());
     if ($method === null) {
-      throw new MethodNotAllowedException();
+      throw new MethodNotAllowedException(
+        $this->getAllowedMethods($request->getUri()->getPath()),
+      );
     }
+
     return $this->routeMethodAndPath($method, $request->getUri()->getPath());
+  }
+
+  private function getAllowedMethods(string $path): keyset<HttpMethod> {
+    $resolver = $this->getResolver();
+    $allowed = keyset[];
+    foreach (HttpMethod::getValues() as $method) {
+      try {
+        list($_responder, $_data) = $resolver->resolve($method, $path);
+        $allowed[] = $method;
+      } catch (NotFoundException $_) {
+        continue;
+      }
+    }
+
+    return $allowed;
   }
 
   private ?IResolver<TResponder> $resolver = null;
@@ -76,9 +92,8 @@ abstract class BaseRouter<+TResponder> {
     if ($routes === null) {
       $routes = Dict\map(
         $this->getRoutes(),
-        $method_routes ==> PrefixMatching\PrefixMap::fromFlatMap(
-          dict($method_routes),
-        ),
+        $method_routes ==>
+          PrefixMatching\PrefixMap::fromFlatMap(dict($method_routes)),
       );
 
       if (!is_dev()) {


### PR DESCRIPTION
this PR adds the `getAllowedMethods()` method to the `MethodNotAllowedException` exception class.

this helps developers to send the correct `Allow` header value.

see : https://tools.ietf.org/html/rfc7231#section-7.4.1
see : https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Allow
see : https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/405


> Note: this PR contains a small BC-break, in case someone is extending the `MethodNotAllowedException` class ( which is unlikely ).

Example : 

```hack
try {
  list($handler, $data) = $router->routeRequest($request);

  $response = await $handler->handle(
    $request->withAttribute('data', $data)
  );

} catch(MethodNotAllowedException $e) {
  $response = new Response(405)
	|> $$->withAddedHeader('Allow', $e->getAllowedMethods());

} catch(NotFoundException $e) {
  $response = new Response(404);

}

await $emitter->emit($response); 
exit(0);
```