### PR TITLE
Add type hints to lambda parameters

### DIFF
--- a/bin/naive-benchmark.php
+++ b/bin/naive-benchmark.php
@@ -82,7 +82,9 @@ final class NaiveBenchmark {
           $expected_responder,
           $responder,
         );
-        $pretty_data = $dict ==> \var_export($dict, true)
+	$pretty_data = (
+	    dict<string, string> $dict
+	  ) ==> \var_export($dict, true)
           |> Str\split($$, "\n")
           |> Vec\map($$, $line ==> '    '.$line)
           |> Str\join($$, "\n");

--- a/src/request-parameters/RequestParametersBase.php
+++ b/src/request-parameters/RequestParametersBase.php
@@ -24,8 +24,9 @@ abstract class RequestParametersBase {
     KeyedTraversable<string, string> $values,
   ) {
     $this->values = new ImmMap($values);
-    $spec_vector_to_map = $specs ==>
-      Dict\pull($specs, $it ==> $it, $it ==> $it->getName());
+    $spec_vector_to_map = (
+      Traversable<RequestParameter> $specs
+    ) ==> Dict\pull($specs, $it ==> $it, $it ==> $it->getName());
 
     $this->requiredSpecs = $spec_vector_to_map($required_specs);
     $this->optionalSpecs = $spec_vector_to_map($optional_specs);


### PR DESCRIPTION
Summary: required for .hhconfig disallow_ambiguous_lambda.
