### PR TITLE
replace `ImmMap` by `KeyedContainer`

### DIFF
--- a/src/router/BaseRouter.php
+++ b/src/router/BaseRouter.php
@@ -15,7 +15,7 @@ use function Facebook\AutoloadMap\Generated\is_dev;
 
 abstract class BaseRouter<+TResponder> {
   abstract protected function getRoutes(
-  ): ImmMap<HttpMethod, ImmMap<string, TResponder>>;
+  ): KeyedContainer<HttpMethod, KeyedContainer<string, TResponder>>;
 
   final public function routeMethodAndPath(
     HttpMethod $method,


### PR DESCRIPTION
The reason why `KeyedContainer` is used here is that we can maintain BC this way ( since `ImmMap` is a `KeyedContainer` )

