### PR TITLE
Require hhvm 4.128 and support autoloading with ext_watchman

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ tests/ export-ignore
 examples/ export-ignore
 data/ export-ignore
 .hhconfig export-ignore
+.hhvmconfig.hdf export-ignore

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [ ubuntu ]
         hhvm:
-          - '4.102'
+          - '4.128'
           - latest
           - nightly
     runs-on: ${{matrix.os}}-latest

--- a/.hhvmconfig.hdf
+++ b/.hhvmconfig.hdf
@@ -1,0 +1,3 @@
+Autoload {
+  Query = {"expression": ["allof", ["type", "f"], ["suffix", ["anyof", "hack", "php"]], ["not",["anyof",["dirname",".var"],["dirname",".git"]]]]}
+}

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,7 @@
   "keywords": ["hack", "router", "routing", "hhvm"],
   "homepage": "https://github.com/hhvm/hack-router",
   "require": {
-    "hhvm": "^4.102",
-    "hhvm/hsl": "^4.0",
+    "hhvm": "^4.128",
     "facebook/hack-http-request-response-interfaces": "^0.2|^0.3"
   },
   "extra": {

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,10 @@
     "hhvm/hhvm-autoload": "^2.0.8|^3.0",
     "hhvm/hacktest": "^2.0",
     "usox/hackttp": "^0.5"
+  },
+  "config": {
+    "allow-plugins": {
+      "hhvm/hhvm-autoload": true
+    }
   }
 }

--- a/hh_autoload.json
+++ b/hh_autoload.json
@@ -5,5 +5,6 @@
   "devRoots": [
     "tests/"
   ],
-  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler"
+  "devFailureHandler": "Facebook\\AutoloadMap\\HHClientFallbackHandler",
+  "useFactsIfAvailable": true
 }

--- a/src/router/BaseRouter.php
+++ b/src/router/BaseRouter.php
@@ -24,7 +24,7 @@ abstract class BaseRouter<+TResponder> {
     $resolver = $this->getResolver();
     try {
       list($responder, $data) = $resolver->resolve($method, $path);
-      $data = Dict\map($data, $value ==> \urldecode($value));
+      $data = Dict\map($data, \urldecode<>);
       return tuple($responder, new ImmMap($data));
     } catch (NotFoundException $e) {
       $allowed = $this->getAllowedMethods($path);
@@ -36,7 +36,7 @@ abstract class BaseRouter<+TResponder> {
         $method === HttpMethod::HEAD && $allowed === keyset[HttpMethod::GET]
       ) {
         list($responder, $data) = $resolver->resolve(HttpMethod::GET, $path);
-        $data = Dict\map($data, $value ==> \urldecode($value));
+        $data = Dict\map($data, \urldecode<>);
         return tuple($responder, new ImmMap($data));
       }
 

--- a/src/router/PrefixMatching/PrefixMap.php
+++ b/src/router/PrefixMatching/PrefixMap.php
@@ -147,14 +147,14 @@ final class PrefixMap<T> {
       return tuple(0, dict[]);
     }
 
-    $lens = Vec\map($keys, $key ==> Str\length($key));
+    $lens = Vec\map($keys, Str\length<>);
     $prefix_length = \min($lens);
     invariant($prefix_length !== 0, "Shouldn't have 0-length prefixes");
     return tuple(
       $prefix_length,
       $keys
         |> Dict\group_by($$, $key ==> Str\slice($key, 0, $prefix_length))
-        |> Dict\map($$, $vec ==> keyset($vec)),
+        |> Dict\map($$, keyset<>),
     );
   }
 

--- a/src/router/PrefixMatchingResolver.php
+++ b/src/router/PrefixMatchingResolver.php
@@ -62,7 +62,7 @@ final class PrefixMatchingResolver<+TResponder>
     $regexps = $map->getRegexps();
     foreach ($regexps as $regexp => $_sub_map) {
       $pattern = '#^'.$regexp.'#';
-      $matches = varray[];
+      $matches = dict[];
 
       if (\preg_match_with_matches($pattern, $path, inout $matches) !== 1) {
         continue;

--- a/src/router/PrefixMatchingResolver.php
+++ b/src/router/PrefixMatchingResolver.php
@@ -23,7 +23,7 @@ final class PrefixMatchingResolver<+TResponder>
   public static function fromFlatMap(
     dict<HttpMethod, dict<string, TResponder>> $map,
   ): PrefixMatchingResolver<TResponder> {
-    $map = Dict\map($map, $flat_map ==> PrefixMap::fromFlatMap($flat_map));
+    $map = Dict\map($map, PrefixMap::fromFlatMap<>);
     return new self($map);
   }
 

--- a/src/router/SimpleRegexpResolver.php
+++ b/src/router/SimpleRegexpResolver.php
@@ -33,7 +33,7 @@ final class SimpleRegexpResolver<+TResponder> implements IResolver<TResponder> {
     }
     $map = $this->map[$method];
     foreach ($map as $regexp => $responder) {
-      $matches = varray[];
+      $matches = dict[];
       if (\preg_match_with_matches($regexp, $path, inout $matches) !== 1) {
         continue;
       }

--- a/src/router/UnknownRouterException.php
+++ b/src/router/UnknownRouterException.php
@@ -11,13 +11,13 @@
 namespace Facebook\HackRouter;
 
 class UnknownRouterException extends InternalServerErrorException {
-  public function __construct(private varray<mixed> $fastRouteData) {
+  public function __construct(private vec<mixed> $fastRouteData) {
     parent::__construct(
       'Unknown FastRoute response: '.\var_export($fastRouteData, true),
     );
   }
 
-  public function getFastRouteData(): varray<mixed> {
+  public function getFastRouteData(): vec<mixed> {
     return $this->fastRouteData;
   }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -14,8 +14,8 @@ use function Facebook\FBExpect\expect;
 use type Facebook\HackTest\DataProvider;
 
 final class ParserTest extends \Facebook\HackTest\HackTest {
-  public function getExamplePatterns(): varray<(string, string)> {
-    return varray[
+  public function getExamplePatterns(): vec<(string, string)> {
+    return vec[
       tuple('/foo', "['/foo']"),
       tuple('/foo/{bar}', "['/foo/', {bar}]"),
       tuple('/foo/[{bar}]', "['/foo/', ?[{bar}]]"),

--- a/tests/RequestParametersTest.php
+++ b/tests/RequestParametersTest.php
@@ -15,38 +15,37 @@ use function Facebook\FBExpect\expect;
 
 final class RequestParametersTest extends \Facebook\HackTest\HackTest {
   public function testStringParam(): void {
-    $parts = varray[new StringRequestParameter(
+    $parts = vec[new StringRequestParameter(
       StringRequestParameterSlashes::WITHOUT_SLASHES,
       'foo',
     )];
     $data = dict['foo' => 'bar'];
-    expect((new RequestParameters($parts, varray[], $data))->getString('foo'))
+    expect((new RequestParameters($parts, vec[], $data))->getString('foo'))
       ->toBeSame('bar');
   }
 
   public function testIntParam(): void {
-    $parts = varray[new IntRequestParameter('foo')];
+    $parts = vec[new IntRequestParameter('foo')];
     $data = dict['foo' => '123'];
-    expect((new RequestParameters($parts, varray[], $data))->getInt('foo'))->toBeSame(
-      123,
-    );
+    expect((new RequestParameters($parts, vec[], $data))->getInt('foo'))
+      ->toBeSame(123);
   }
 
   public function testFetchingStringAsInt(): void {
     expect(() ==> {
-      $parts = varray[new StringRequestParameter(
+      $parts = vec[new StringRequestParameter(
         StringRequestParameterSlashes::WITHOUT_SLASHES,
         'foo',
       )];
       $data = dict['foo' => 'bar'];
-      (new RequestParameters($parts, varray[], $data))->getInt('foo');
+      (new RequestParameters($parts, vec[], $data))->getInt('foo');
     })->toThrow(InvariantException::class);
   }
 
   public function testEnumParam(): void {
-    $parts = varray[new EnumRequestParameter(TestIntEnum::class, 'foo')];
+    $parts = vec[new EnumRequestParameter(TestIntEnum::class, 'foo')];
     $data = dict['foo' => (string)TestIntEnum::BAR];
-    $value = (new RequestParameters($parts, varray[], $data))->getEnum(
+    $value = (new RequestParameters($parts, vec[], $data))->getEnum(
       TestIntEnum::class,
       'foo',
     );
@@ -85,7 +84,7 @@ final class RequestParametersTest extends \Facebook\HackTest\HackTest {
       'bar' => '123',
       'baz' => (string)TestIntEnum::FOO,
     ];
-    $params = new RequestParameters($parts, varray[], $data);
+    $params = new RequestParameters($parts, vec[], $data);
     expect($params->getString('foo'))->toBeSame('some string');
     expect($params->getInt('bar'))->toBeSame(123);
     expect($params->getEnum(TestIntEnum::class, 'baz'))->toBeSame(
@@ -95,8 +94,8 @@ final class RequestParametersTest extends \Facebook\HackTest\HackTest {
 
   public function testGetOptional(): void {
     $params = new RequestParameters(
-      varray[],
-      varray[new StringRequestParameter(
+      vec[],
+      vec[new StringRequestParameter(
         StringRequestParameterSlashes::WITHOUT_SLASHES,
         'foo',
       )],
@@ -107,8 +106,8 @@ final class RequestParametersTest extends \Facebook\HackTest\HackTest {
 
   public function testGetMissingOptional(): void {
     $params = new RequestParameters(
-      varray[],
-      varray[new StringRequestParameter(
+      vec[],
+      vec[new StringRequestParameter(
         StringRequestParameterSlashes::WITHOUT_SLASHES,
         'foo',
       )],
@@ -120,8 +119,8 @@ final class RequestParametersTest extends \Facebook\HackTest\HackTest {
   public function testGetOptionalAsRequired(): void {
     expect(() ==> {
       $params = new RequestParameters(
-        varray[],
-        varray[new StringRequestParameter(
+        vec[],
+        vec[new StringRequestParameter(
           StringRequestParameterSlashes::WITHOUT_SLASHES,
           'foo',
         )],
@@ -134,11 +133,11 @@ final class RequestParametersTest extends \Facebook\HackTest\HackTest {
   public function testGetRequiredAsOptional(): void {
     expect(() ==> {
       $params = new RequestParameters(
-        varray[new StringRequestParameter(
+        vec[new StringRequestParameter(
           StringRequestParameterSlashes::WITHOUT_SLASHES,
           'foo',
         )],
-        varray[],
+        vec[],
         dict['foo' => 'bar'],
       );
       $params->getOptionalString('foo');

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -96,7 +96,7 @@ final class RouterTest extends \Facebook\HackTest\HackTest {
       tuple('simple regexp', $map ==> new SimpleRegexpResolver($map)),
       tuple(
         'prefix matching',
-        $map ==> PrefixMatchingResolver::fromFlatMap($map),
+        PrefixMatchingResolver::fromFlatMap<>,
       ),
     ];
   }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -37,8 +37,8 @@ final class RouterTest extends \Facebook\HackTest\HackTest {
   ];
 
   public function expectedMatches(
-  ): varray<(string, string, dict<string, string>)> {
-    return varray[
+  ): vec<(string, string, dict<string, string>)> {
+    return vec[
       tuple('/foo', '/foo', dict[]),
       tuple('/foo/', '/foo/', dict[]),
       tuple('/foo/bar', '/foo/bar', dict[]),
@@ -88,13 +88,10 @@ final class RouterTest extends \Facebook\HackTest\HackTest {
     $_ = $this->expectedMatchesWithResolvers();
   }
 
-  public function getAllResolvers(
-  ): vec<
-    (
-      string,
-      (function(dict<HttpMethod, dict<string, string>>): IResolver<string>),
-    )
-  > {
+  public function getAllResolvers(): vec<(
+    string,
+    (function(dict<HttpMethod, dict<string, string>>): IResolver<string>),
+  )> {
     return vec[
       tuple('simple regexp', $map ==> new SimpleRegexpResolver($map)),
       tuple(
@@ -142,10 +139,8 @@ final class RouterTest extends \Facebook\HackTest\HackTest {
     $router = $this->getRouter()->setResolver($factory($map));
 
     // HEAD -> GET ( re-routing )
-    list($responder, $_data) = $router->routeMethodAndPath(
-      HttpMethod::HEAD,
-      '/get',
-    );
+    list($responder, $_data) =
+      $router->routeMethodAndPath(HttpMethod::HEAD, '/get');
     expect($responder)->toBeSame('get');
 
     // GET -> HEAD
@@ -208,10 +203,8 @@ final class RouterTest extends \Facebook\HackTest\HackTest {
     dict<string, string> $_expected_data,
   ): void {
     $router = $this->getRouter();
-    list($direct_responder, $direct_data) = $router->routeMethodAndPath(
-      HttpMethod::GET,
-      $path,
-    );
+    list($direct_responder, $direct_data) =
+      $router->routeMethodAndPath(HttpMethod::GET, $path);
 
     expect($path[0])->toBeSame('/');
 

--- a/tests/UriPatternTest.php
+++ b/tests/UriPatternTest.php
@@ -71,8 +71,14 @@ final class UriPatternTest extends \Facebook\HackTest\HackTest {
     )->toBeSame((new IntRequestParameter('foo'))->assert('123'));
   }
 
-  public function exampleInvalidInts(): varray<varray<string>> {
-    return varray[varray['foo'], varray['0123foo'], varray['0.123foo'], varray['0.123'], varray['0x1e3']];
+  public function exampleInvalidInts(): vec<vec<string>> {
+    return vec[
+      vec['foo'],
+      vec['0123foo'],
+      vec['0.123foo'],
+      vec['0.123'],
+      vec['0x1e3'],
+    ];
   }
 
   <<DataProvider('exampleInvalidInts')>>


### PR DESCRIPTION
The hsl is always built-in.
ext_watchman and HH\Facts are always available.
varray eq vec and darray eq dict is always true.
All legacy arrays have been replaced with Hack arrays.