### PR TITLE
make HEAD/GET method rewrite configurable

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -11,12 +11,12 @@ jobs:
       # Run tests on all OS's and HHVM versions, even if one fails
       fail-fast: false
       matrix:
-        os: [ ubuntu ]
+        os: [ ubuntu-20.04 ]
         hhvm:
           - '4.128'
-          - latest
-          - nightly
-    runs-on: ${{matrix.os}}-latest
+          - '4.153'
+          - '4.168'
+    runs-on: ${{matrix.os}}
     steps:
       - uses: actions/checkout@v2
       - name: Create branch for version alias

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
         hhvm:
-          - '4.128'
           - '4.153'
           - '4.168'
     runs-on: ${{matrix.os}}

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ final class BaseRouterExample extends BaseRouter<TResponder> {
 ```
 
 Simplified for conciseness - see
-[`examples/BaseRouterExample.php`](examples/BaseRouterExample.php) for
+[`examples/RunBaseRouterExample.php`](examples/RunBaseRouterExample.php) for
 full executable example.
 
 UriPatterns
@@ -87,7 +87,7 @@ $link = UserPageController::getUriBuilder()
 ```
 
 These examples are simplified for conciseness - see
-[`examples/UriPatternsExample.php`](examples/UriPatternsExample.php) for
+[`examples/RunUriPatternsExample.php`](examples/RunUriPatternsExample.php) for
 full executable example.
 
 Codegen

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "keywords": ["hack", "router", "routing", "hhvm"],
   "homepage": "https://github.com/hhvm/hack-router",
   "require": {
-    "hhvm": "^4.128",
+    "hhvm": "^4.153",
     "facebook/hack-http-request-response-interfaces": "^0.2|^0.3"
   },
   "extra": {

--- a/examples/RunBaseRouterExample.php
+++ b/examples/RunBaseRouterExample.php
@@ -1,0 +1,30 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/***********
+ * IF YOU EDIT THIS FILE also update the snippet in README.md
+ ***********/
+
+namespace Facebook\HackRouter\Examples\BaseRouterExample;
+
+<<__EntryPoint>>
+function main(): noreturn {
+  require_once __DIR__.'/../vendor/autoload.hack';
+  \Facebook\AutoloadMap\initialize();
+
+  $router = new BaseRouterExample();
+  foreach (get_example_inputs() as $input) {
+    list($method, $path) = $input;
+
+    list($responder, $params) = $router->routeMethodAndPath($method, $path);
+    \printf("%s %s\n\t%s\n", $method, $path, $responder(dict($params)));
+  }
+  exit(0);
+}

--- a/examples/RunUriPatternsExample.php
+++ b/examples/RunUriPatternsExample.php
@@ -1,0 +1,30 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+/***********
+ * IF YOU EDIT THIS FILE also update the snippet in README.md
+ ***********/
+
+namespace Facebook\HackRouter\Examples\UrlPatternsExample;
+
+use type Facebook\HackRouter\HttpMethod;
+
+<<__EntryPoint>>
+function main(): void {
+  require_once __DIR__.'/../vendor/autoload.hack';
+  \Facebook\AutoloadMap\initialize();
+
+  $router = new UriPatternsExample();
+  foreach (get_example_paths() as $path) {
+    list($controller, $params) =
+      $router->routeMethodAndPath(HttpMethod::GET, $path);
+    \printf("GET %s\n\t%s\n", $path, (new $controller($params))->getResponse());
+  }
+}

--- a/examples/lib/BaseRouterExample.php
+++ b/examples/lib/BaseRouterExample.php
@@ -14,15 +14,13 @@
 
 namespace Facebook\HackRouter\Examples\BaseRouterExample;
 
-require_once(__DIR__.'/../vendor/hh_autoload.php');
-
 use type Facebook\HackRouter\{BaseRouter, HttpMethod};
 
 /** This can be whatever you want; in this case, it's a
  * callable, but classname<MyWebControllerBase> is also a
  * common choice.
  */
-type TResponder = (function(dict<string, string>):string);
+type TResponder = (function(dict<string, string>): string);
 
 final class BaseRouterExample extends BaseRouter<TResponder> {
   <<__Override>>
@@ -30,10 +28,8 @@ final class BaseRouterExample extends BaseRouter<TResponder> {
   ): ImmMap<HttpMethod, ImmMap<string, TResponder>> {
     return ImmMap {
       HttpMethod::GET => ImmMap {
-        '/' =>
-          ($_params) ==> 'Hello, world',
-        '/user/{user_name}' =>
-          ($params) ==> 'Hello, '.$params['user_name'],
+        '/' => ($_params) ==> 'Hello, world',
+        '/user/{user_name}' => ($params) ==> 'Hello, '.$params['user_name'],
       },
       HttpMethod::POST => ImmMap {
         '/' => ($_params) ==> 'Hello, POST world',
@@ -49,21 +45,4 @@ function get_example_inputs(): ImmVector<(HttpMethod, string)> {
     tuple(HttpMethod::GET, '/user/bar'),
     tuple(HttpMethod::POST, '/'),
   };
-}
-
-<<__EntryPoint>>
-function main(): noreturn {
-  $router = new BaseRouterExample();
-  foreach (get_example_inputs() as $input) {
-    list($method, $path) = $input;
-
-    list($responder, $params) = $router->routeMethodAndPath($method, $path);
-    \printf(
-      "%s %s\n\t%s\n",
-      $method,
-      $path,
-      $responder(dict($params)),
-    );
-  }
-  exit(0);
 }

--- a/examples/lib/UriPatternsExample.php
+++ b/examples/lib/UriPatternsExample.php
@@ -14,16 +14,14 @@
 
 namespace Facebook\HackRouter\Examples\UrlPatternsExample;
 
-require_once(__DIR__.'/../vendor/hh_autoload.php');
-
-use   type Facebook\HackRouter\{
+use type Facebook\HackRouter\{
   BaseRouter,
   GetFastRoutePatternFromUriPattern,
   GetUriBuilderFromUriPattern,
   HasUriPattern,
   HttpMethod,
   RequestParameters,
-  UriPattern
+  UriPattern,
 };
 
 <<__ConsistentConstruct>>
@@ -38,12 +36,10 @@ abstract class WebController implements HasUriPattern {
     return $this->uriParameters;
   }
 
-  public function __construct(
-    ImmMap<string, string> $uri_parameter_values,
-  ) {
+  public function __construct(ImmMap<string, string> $uri_parameter_values) {
     $this->uriParameters = new RequestParameters(
       static::getUriPattern()->getParameters(),
-      ImmVector { },
+      ImmVector {},
       $uri_parameter_values,
     );
   }
@@ -86,8 +82,7 @@ final class UriPatternsExample extends BaseRouter<TResponder> {
   }
 
   <<__Override>>
-  public function getRoutes(
-  ): ImmMap<HttpMethod, ImmMap<string, TResponder>> {
+  public function getRoutes(): ImmMap<HttpMethod, ImmMap<string, TResponder>> {
     $urls_to_controllers = dict[];
     foreach (self::getControllers() as $controller) {
       $pattern = $controller::getFastRoutePattern();
@@ -107,21 +102,3 @@ function get_example_paths(): ImmVector<string> {
       ->getPath(),
   };
 }
-
-function main(): void {
-  $router = new UriPatternsExample();
-  foreach (get_example_paths() as $path) {
-    list($controller, $params) = $router->routeMethodAndPath(
-      HttpMethod::GET,
-      $path,
-    );
-    \printf(
-      "GET %s\n\t%s\n",
-      $path,
-      (new $controller($params))->getResponse(),
-    );
-  }
-}
-
-/* HH_IGNORE_ERROR[1002] top-level statement in strict file */
-main();

--- a/src/http-exceptions/InternalServerErrorException.php
+++ b/src/http-exceptions/InternalServerErrorException.php
@@ -10,5 +10,5 @@
 
 namespace Facebook\HackRouter;
 
-class InternalServerErrorException extends HttpException {
-}
+// HHAST_IGNORE_ERROR[FinalOrAbstractClass] @see UnknownRouterException.
+class InternalServerErrorException extends HttpException {}

--- a/src/http-exceptions/MethodNotAllowedException.php
+++ b/src/http-exceptions/MethodNotAllowedException.php
@@ -10,6 +10,7 @@
 
 namespace Facebook\HackRouter;
 
+// HHAST_IGNORE_ERROR[FinalOrAbstractClass] maybe extended outside this library.
 class MethodNotAllowedException extends HttpException {
   public function __construct(
     protected keyset<HttpMethod> $allowed,

--- a/src/http-exceptions/NotFoundException.php
+++ b/src/http-exceptions/NotFoundException.php
@@ -10,5 +10,5 @@
 
 namespace Facebook\HackRouter;
 
-class NotFoundException extends HttpException {
-}
+// HHAST_IGNORE_ERROR[FinalOrAbstractClass] maybe extended outside this library.
+class NotFoundException extends HttpException {}

--- a/src/request-parameters/EnumRequestParameter.php
+++ b/src/request-parameters/EnumRequestParameter.php
@@ -15,15 +15,13 @@ use namespace HH\Lib\{Str, Vec};
 // HHAST_IGNORE_ERROR[FinalOrAbstractClass] maybe extended outside this library.
 class EnumRequestParameter<T> extends TypedUriParameter<T> {
   public function __construct(
-    /* HH_FIXME[2053] */
-    private classname<\HH\BuiltinEnum<T>> $enumClass,
+    private \HH\enumname<T> $enumClass,
     string $name,
   ) {
     parent::__construct($name);
   }
 
-  /* HH_FIXME[2053] */
-  final public function getEnumName(): classname<\HH\BuiltinEnum<T>> {
+  final public function getEnumName(): \HH\enumname<T> {
     return $this->enumClass;
   }
 

--- a/src/request-parameters/EnumRequestParameter.php
+++ b/src/request-parameters/EnumRequestParameter.php
@@ -12,7 +12,12 @@ namespace Facebook\HackRouter;
 
 use namespace HH\Lib\{Str, Vec};
 
-// HHAST_IGNORE_ERROR[FinalOrAbstractClass] maybe extended outside this library.
+/**
+ * WARNING: hh_client will not infer a correct enum type when given `SomeEnum::class`.
+ * @see RequestParametersTest::testInvalidEnumParamToUri() (grep for @ref)
+ * `EnumRequestParameterExplicit` is typesafe, so you can use that instead.
+ */
+// HHAST_IGNORE_ERROR[FinalOrAbstractClass] comment above.
 class EnumRequestParameter<T> extends TypedUriParameter<T> {
   public function __construct(
     private \HH\enumname<T> $enumClass,

--- a/src/request-parameters/EnumRequestParameter.php
+++ b/src/request-parameters/EnumRequestParameter.php
@@ -12,6 +12,7 @@ namespace Facebook\HackRouter;
 
 use namespace HH\Lib\{Str, Vec};
 
+// HHAST_IGNORE_ERROR[FinalOrAbstractClass] maybe extended outside this library.
 class EnumRequestParameter<T> extends TypedUriParameter<T> {
   public function __construct(
     /* HH_FIXME[2053] */
@@ -42,7 +43,7 @@ class EnumRequestParameter<T> extends TypedUriParameter<T> {
   public function getRegExpFragment(): ?string {
     $class = $this->enumClass;
     $values = $class::getValues();
-    $sub_fragments = Vec\map($values, $value ==> \preg_quote((string) $value));
+    $sub_fragments = Vec\map($values, $value ==> \preg_quote((string)$value));
     return '(?:'.Str\join($sub_fragments, '|').')';
   }
 }

--- a/src/request-parameters/EnumRequestParameterExplicit.php
+++ b/src/request-parameters/EnumRequestParameterExplicit.php
@@ -1,0 +1,14 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HackRouter;
+
+final class EnumRequestParameterExplicit<<<__Explicit>> T>
+  extends EnumRequestParameter<T> {}

--- a/src/request-parameters/RequestParameterGetters.php
+++ b/src/request-parameters/RequestParameterGetters.php
@@ -32,8 +32,7 @@ trait RequestParameterGetters {
   }
 
   final public function getEnum<TValue>(
-    /* HH_FIXME[2053] */
-    classname<\HH\BuiltinEnum<TValue>> $class,
+    \HH\enumname<TValue> $class,
     string $name,
   ): TValue {
     $value = $this->getEnumImpl(
@@ -45,8 +44,7 @@ trait RequestParameterGetters {
   }
 
   final public function getOptionalEnum<TValue>(
-    /* HH_FIXME[2053] */
-    classname<\HH\BuiltinEnum<TValue>> $class,
+    \HH\enumname<TValue> $class,
     string $name,
   ): ?TValue {
     return $this->getEnumImpl(
@@ -58,8 +56,7 @@ trait RequestParameterGetters {
 
   final private function getEnumImpl<TValue>(
     EnumRequestParameter<TValue> $spec,
-    /* HH_FIXME[2053] */
-    classname<\HH\BuiltinEnum<TValue>> $class,
+    \HH\enumname<TValue> $class,
     string $name,
   ): ?TValue {
     invariant(

--- a/src/request-parameters/RequestParametersBase.php
+++ b/src/request-parameters/RequestParametersBase.php
@@ -24,9 +24,8 @@ abstract class RequestParametersBase {
     KeyedTraversable<string, string> $values,
   ) {
     $this->values = new ImmMap($values);
-    $spec_vector_to_map = (
-      Traversable<RequestParameter> $specs
-    ) ==> Dict\pull($specs, $it ==> $it, $it ==> $it->getName());
+    $spec_vector_to_map = (Traversable<RequestParameter> $specs) ==>
+      Dict\pull($specs, $it ==> $it, $it ==> $it->getName());
 
     $this->requiredSpecs = $spec_vector_to_map($required_specs);
     $this->optionalSpecs = $spec_vector_to_map($optional_specs);
@@ -63,14 +62,13 @@ abstract class RequestParametersBase {
   ): T {
     $spec = $specs[$name];
     invariant(
-      /* HH_FIXME[4162] need reified generics */
       \is_a($spec, $class),
       'Expected %s to be a %s, got %s',
       $name,
       $class,
       \get_class($spec),
     );
-    return /* HH_FIXME[4110] */ $spec;
+    return \HH\FIXME\UNSAFE_CAST<RequestParameter, T>($spec, 'is_a($spec, $class) ~= $spec is T');
   }
 
   final protected function getSimpleTyped<T>(

--- a/src/router/BaseRouter.php
+++ b/src/router/BaseRouter.php
@@ -14,9 +14,12 @@ use namespace HH\Lib\{C, Dict};
 use function Facebook\AutoloadMap\Generated\is_dev;
 
 abstract class BaseRouter<+TResponder> {
-  public function __construct(
-    private BaseRouterOptions $options = shape('use_get_responder_for_head' => true)
-  ) {}
+  private bool $useGetResponderForHead;
+
+  public function __construct(?BaseRouterOptions $options = null) {
+    $this->useGetResponderForHead =
+      Shapes::idx($options, 'use_get_responder_for_head', true);
+  }
 
   abstract protected function getRoutes(
   ): KeyedContainer<HttpMethod, KeyedContainer<string, TResponder>>;
@@ -37,7 +40,9 @@ abstract class BaseRouter<+TResponder> {
       }
 
       if (
-        $this->options['use_get_responder_for_head'] && $method === HttpMethod::HEAD && $allowed === keyset[HttpMethod::GET]
+        $this->useGetResponderForHead &&
+        $method === HttpMethod::HEAD &&
+        $allowed === keyset[HttpMethod::GET]
       ) {
         list($responder, $data) = $resolver->resolve(HttpMethod::GET, $path);
         $data = Dict\map($data, \urldecode<>);

--- a/src/router/BaseRouter.php
+++ b/src/router/BaseRouter.php
@@ -14,6 +14,10 @@ use namespace HH\Lib\{C, Dict};
 use function Facebook\AutoloadMap\Generated\is_dev;
 
 abstract class BaseRouter<+TResponder> {
+  public function __construct(
+    private BaseRouterOptions $options = shape('use_get_responder_for_head' => true)
+  ) {}
+
   abstract protected function getRoutes(
   ): KeyedContainer<HttpMethod, KeyedContainer<string, TResponder>>;
 
@@ -33,7 +37,7 @@ abstract class BaseRouter<+TResponder> {
       }
 
       if (
-        $method === HttpMethod::HEAD && $allowed === keyset[HttpMethod::GET]
+        $this->options['use_get_responder_for_head'] && $method === HttpMethod::HEAD && $allowed === keyset[HttpMethod::GET]
       ) {
         list($responder, $data) = $resolver->resolve(HttpMethod::GET, $path);
         $data = Dict\map($data, \urldecode<>);

--- a/src/router/BaseRouterOptions.php
+++ b/src/router/BaseRouterOptions.php
@@ -1,0 +1,16 @@
+<?hh // strict
+
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HackRouter;
+
+type BaseRouterOptions = shape(
+  'use_get_responder_for_head' => bool,
+);

--- a/src/router/BaseRouterOptions.php
+++ b/src/router/BaseRouterOptions.php
@@ -12,5 +12,5 @@
 namespace Facebook\HackRouter;
 
 type BaseRouterOptions = shape(
-  'use_get_responder_for_head' => bool,
+  ?'use_get_responder_for_head' => bool,
 );

--- a/src/router/UnknownRouterException.php
+++ b/src/router/UnknownRouterException.php
@@ -10,6 +10,7 @@
 
 namespace Facebook\HackRouter;
 
+// HHAST_IGNORE_ERROR[FinalOrAbstractClass] maybe extended outside this library.
 class UnknownRouterException extends InternalServerErrorException {
   public function __construct(private vec<mixed> $fastRouteData) {
     parent::__construct(

--- a/src/uri-patterns/UriBuilderBase.php
+++ b/src/uri-patterns/UriBuilderBase.php
@@ -80,12 +80,15 @@ abstract class UriBuilderBase {
       $parameter_type,
       \get_class($part),
     );
+    $part = \HH\FIXME\UNSAFE_CAST<RequestParameter, TypedUriParameter<T>>(
+      $part,
+      'is_a($part, $parameter_type) ~= $part is TypedUriParameter<T>',
+    );
     invariant(
       !$this->values->containsKey($name),
       'trying to set %s twice',
       $name,
     );
-    /* HH_FIXME[4053] need reified generics */
     $this->values[$name] = $part->getUriFragment($value);
     return $this;
   }

--- a/src/uri-patterns/UriBuilderSetters.php
+++ b/src/uri-patterns/UriBuilderSetters.php
@@ -22,7 +22,7 @@ trait UriBuilderSetters {
   }
 
   final public function setEnum<T>(
-    /* HH_FIXME[2053] */ classname<\HH\BuiltinEnum<T>> $class,
+    \HH\enumname<T> $class,
     string $name,
     T $value,
   ): this {

--- a/src/uri-patterns/UriPattern.php
+++ b/src/uri-patterns/UriPattern.php
@@ -68,8 +68,7 @@ class UriPattern implements HasFastRouteFragment {
   }
 
   final public function enum<T>(
-    /* HH_FIXME[2053] \HH\BuiltinEnum is an implementation detail */
-    classname<\HH\BuiltinEnum<T>> $enum_class,
+    \HH\enumname<T> $enum_class,
     string $name,
   ): this {
     return $this->appendPart(new EnumRequestParameter($enum_class, $name));

--- a/src/uri-patterns/UriPattern.php
+++ b/src/uri-patterns/UriPattern.php
@@ -10,8 +10,8 @@
 
 namespace Facebook\HackRouter;
 
-// Non-final so you can extend it with additional convenience
-// methods.
+// Non-final so you can extend it with additional convenience methods.
+// HHAST_IGNORE_ERROR[FinalOrAbstractClass] message above.
 class UriPattern implements HasFastRouteFragment {
   private Vector<UriPatternPart> $parts = Vector {};
 
@@ -31,8 +31,8 @@ class UriPattern implements HasFastRouteFragment {
 
   final public function getParameters(): ImmVector<UriParameter> {
     $out = Vector {};
-    foreach($this->parts as $part) {
-      if($part is UriParameter) {
+    foreach ($this->parts as $part) {
+      if ($part is UriParameter) {
         $out->add($part);
       }
     }

--- a/tests/RequestParametersTest.php
+++ b/tests/RequestParametersTest.php
@@ -62,11 +62,26 @@ final class RequestParametersTest extends \Facebook\HackTest\HackTest {
     );
   }
 
+  // @ref EnumRequestParameter<T>
   public function testInvalidEnumParamToUri(): void {
     expect(() ==> {
       $part = (new EnumRequestParameter(TestIntEnum::class, 'foo'));
-      /* HH_IGNORE_ERROR[4110] intentionally bad type */
+      // hh_client expands the inferred generic here to include TestStringEnum.
+      // This used to be a type error in a previous version of hhvm!
       $_throws = $part->getUriFragment(TestStringEnum::BAR);
+    })->toThrow(\UnexpectedValueException::class);
+  }
+
+  public function testInvalidEnumExplicitParamToUri(): void {
+    expect(() ==> {
+      $part = (
+        new EnumRequestParameterExplicit<TestIntEnum>(TestIntEnum::class, 'foo')
+      );
+      $value = \HH\FIXME\UNSAFE_CAST<TestStringEnum, TestIntEnum>(
+        TestStringEnum::BAR,
+        'Telling lies for the purpose of testing.',
+      );
+      $_throws = $part->getUriFragment($value);
     })->toThrow(\UnexpectedValueException::class);
   }
 

--- a/tests/RouterHeadToGetDisabledTest.php
+++ b/tests/RouterHeadToGetDisabledTest.php
@@ -1,0 +1,56 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HackRouter;
+
+use function Facebook\FBExpect\expect;
+use type Facebook\HackRouter\Tests\NoHeadGetRewriteRouter;
+use type Facebook\HackTest\DataProvider;
+
+final class RouterHeadToGetDisabledTest extends \Facebook\HackTest\HackTest {
+  public function getAllResolvers(): vec<(
+    string,
+    (function(dict<HttpMethod, dict<string, string>>): IResolver<string>),
+  )> {
+    return vec[
+      tuple('simple regexp', $map ==> new SimpleRegexpResolver($map)),
+      tuple('prefix matching', PrefixMatchingResolver::fromFlatMap<>),
+    ];
+  }
+
+  <<DataProvider('getAllResolvers')>>
+  public function testMethodNotAllowedResponses(
+    string $_name,
+    (function(
+      dict<HttpMethod, dict<string, string>>,
+    ): IResolver<string>) $factory,
+  ): void {
+    $map = dict[
+      HttpMethod::GET => dict['/get' => 'get'],
+      HttpMethod::HEAD => dict['/head' => 'head'],
+    ];
+
+    $router = $this->getRouter()->setResolver($factory($map));
+
+    // GET -> HEAD ( no re-routing ), deviating from the default behavior.
+    $e = expect(() ==> $router->routeMethodAndPath(HttpMethod::HEAD, '/get'))
+      ->toThrow(MethodNotAllowedException::class);
+    expect($e->getAllowedMethods())->toBeSame(keyset[HttpMethod::GET]);
+
+    // GET -> HEAD
+    $e = expect(() ==> $router->routeMethodAndPath(HttpMethod::GET, '/head'))
+      ->toThrow(MethodNotAllowedException::class);
+    expect($e->getAllowedMethods())->toBeSame(keyset[HttpMethod::HEAD]);
+  }
+
+  private function getRouter(): NoHeadGetRewriteRouter<string> {
+    return new NoHeadGetRewriteRouter(dict[]);
+  }
+}

--- a/tests/lib/NoHeadGetRewriteRouter.php
+++ b/tests/lib/NoHeadGetRewriteRouter.php
@@ -1,0 +1,43 @@
+<?hh // strict
+/*
+ *  Copyright (c) 2015-present, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the MIT license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ */
+
+namespace Facebook\HackRouter\Tests;
+
+use type Facebook\HackRouter\{BaseRouter, HttpMethod, IResolver};
+
+final class NoHeadGetRewriteRouter<T> extends BaseRouter<T> {
+  public function __construct(
+    private dict<string, T> $routes,
+    private ?IResolver<T> $resolver = null,
+  ) {
+    parent::__construct(shape('use_get_responder_for_head' => false));
+  }
+
+  <<__Override>>
+  protected function getRoutes(): ImmMap<HttpMethod, ImmMap<string, T>> {
+    return ImmMap {
+      HttpMethod::GET => new ImmMap($this->routes),
+    };
+  }
+
+  public function setResolver(IResolver<T> $resolver): this {
+    $this->resolver = $resolver;
+    return $this;
+  }
+
+  <<__Override>>
+  protected function getResolver(): IResolver<T> {
+    $r = $this->resolver;
+    if ($r === null) {
+      return parent::getResolver();
+    }
+    return $r;
+  }
+}

--- a/tests/lib/TestRouter.php
+++ b/tests/lib/TestRouter.php
@@ -21,6 +21,7 @@ final class TestRouter<T> extends BaseRouter<T> {
     private dict<string, T> $routes,
     private ?IResolver<T> $resolver = null,
   ) {
+    parent::__construct();
   }
 
   <<__Override>>


### PR DESCRIPTION
fixes #15

Fixes:
 - Makes HEAD -> GET rewrite configurable

With great thanks to @azjezz.

`Unverified`, since azjezz requires their signature be present on commits that are authored by them.

**Includes #30 for the CI changes. Can revert the rebase if need be. I didn't want to fix the CI twice :slightly_smiling_face:.**